### PR TITLE
Allowance when ledger expired

### DIFF
--- a/mock-sep-41/src/contract.rs
+++ b/mock-sep-41/src/contract.rs
@@ -56,6 +56,10 @@ impl MockToken {
 impl Token for MockToken {
     fn allowance(e: Env, from: Address, spender: Address) -> i128 {
         let result = storage::get_allowance(&e, &from, &spender);
+        if result.expiration_ledger < e.ledger().sequence() {
+            return 0;
+        }
+
         result.amount
     }
 


### PR DESCRIPTION
This PR fixes an issue where the returned allowance doesn't account for `expiration_ledger`. Anyone can extend the TTL of storage entries and it's dangerous to rely on TTL expiration for sensitive cases such as that one.